### PR TITLE
Replace MD lint with RSpec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,13 +20,17 @@ gem "middleman-rouge"
 # Markdown engine
 gem "redcarpet"
 
+# Rake
+gem 'rake'
+
 # Styling libraries
 gem 'bitters', '~> 1.2'
 gem 'bourbon', '~> 4.2', '>= 4.2.6'
 gem 'neat', '~> 1.7', '>= 1.7.4'
 
-# Markdown lint
-gem "mdl"
+# Integration tests
+gem 'rspec', '~> 3.4'
+gem 'capybara', '~> 2.4.4'
 
 # Guard
 gem "guard"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,7 @@ GEM
       sass (>= 3.3.0, < 3.5)
     compass-import-once (1.0.5)
       sass (>= 3.2, < 3.5)
+    diff-lcs (1.2.5)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
@@ -92,10 +93,6 @@ GEM
       rb-inotify (>= 0.9.7)
     lumberjack (1.0.10)
     map (6.6.0)
-    mdl (0.2.1)
-      kramdown (~> 1.5, >= 1.5.0)
-      mixlib-cli (~> 1.5, >= 1.5.0)
-      mixlib-config (~> 2.1, >= 2.1.0)
     method_source (0.8.2)
     middleman (3.4.1)
       coffee-script (~> 2.2)
@@ -150,8 +147,6 @@ GEM
     mime-types-data (3.2016.0221)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
-    mixlib-cli (1.5.0)
-    mixlib-config (2.2.1)
     multi_json (1.11.2)
     neat (1.7.4)
       bourbon (>= 4.0)
@@ -178,11 +173,25 @@ GEM
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
+    rake (10.5.0)
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
     redcarpet (3.3.4)
     rouge (1.10.1)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.1)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-mocks (3.4.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-support (3.4.1)
     ruby-progressbar (1.7.5)
     sass (3.4.21)
     shellany (0.0.1)
@@ -219,16 +228,18 @@ PLATFORMS
 DEPENDENCIES
   bitters (~> 1.2)
   bourbon (~> 4.2, >= 4.2.6)
+  capybara (~> 2.4.4)
   guard
   guard-shell
-  mdl
   middleman (~> 3.4.1)
   middleman-livereload (~> 3.4, >= 3.4.6)
   middleman-rouge
   middleman-s3_sync (~> 3.3, >= 3.3.9)
   middleman-search_engine_sitemap
   neat (~> 1.7, >= 1.7.4)
+  rake
   redcarpet
+  rspec (~> 3.4)
   terminal-notifier-guard
 
 BUNDLED WITH

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+require 'rspec/core/rake_task'
+
 task :default => :build
 
 desc "Build the website from source"
@@ -11,6 +13,11 @@ task :preview do
   sh "bundle exec middleman server"
 end
 
+RSpec::Core::RakeTask.new(:spec)
+
+desc "Run integration tests"
+task :test => :spec
+
 desc "Deploy website to S3"
 task :deploy => :build do
   sh "bundle exec middleman s3_sync"
@@ -20,12 +27,4 @@ desc "Deploy from CI system"
 task :cideploy => :build do
   sh "aws s3 rm s3://docs.freistilbox.com --region eu-west-1 --recursive"
   sh "aws s3 sync build s3://docs.freistilbox.com --region eu-west-1 --acl public-read --cache-control \"public, max-age=86400\""
-end
-
-desc "Test documentation"
-task :test do
-  source_files = Rake::FileList["source/**/*.md"]
-  source_files.each do |md|
-    sh "awk -f md-rm-frontmatter.awk #{md} | mdl -s relaxed"
-  end
 end

--- a/source/index.md
+++ b/source/index.md
@@ -12,7 +12,7 @@ you need to know.
 If you're new to freistilbox, get started with our
 [tutorial](/getting_started/index.html).
 
-And if you've got any questions that you don't find answered here, just
-[contact our technical support](/important_details/support.html) and we'll get
-it sorted out!
+And if you've got any questions that you don't find answered here, just contact
+our [technical support](/important_details/support.html) and we'll get it sorted
+out!
 

--- a/spec/features/index_spec.rb
+++ b/spec/features/index_spec.rb
@@ -1,0 +1,15 @@
+require "spec_helper"
+
+describe "Start page", type: :feature do
+  before do
+    visit "/"
+  end
+
+  it "links to tutorial" do
+    expect(page).to have_selector(:link_or_button, "tutorial")
+  end
+
+  it "links to support contacts" do
+    expect(page).to have_selector(:link_or_button, "technical support")
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,12 @@
+require "middleman"
+require 'rspec'
+require 'capybara/rspec'
+
+require 'middleman-core/load_paths'
+Middleman.setup_load_paths
+
+Capybara.app = Middleman::Application.server.inst do
+  set :root, File.expand_path(File.join(File.dirname(__FILE__), '..'))
+  set :environment, :development
+  set :show_exceptions, false
+end


### PR DESCRIPTION
The style imposed by Markdown Lint can not be customised, which is
annoying. I've replaced it with RSpec, let's just build our own test
harness.
